### PR TITLE
Make `-march=native` opt-in

### DIFF
--- a/hermes-json.cabal
+++ b/hermes-json.cabal
@@ -34,7 +34,7 @@ flag strict
 
 flag native_comp
   description: Target native architecture for C++ compiler
-  default: True
+  default: False
   manual: True
 
 flag debug


### PR DESCRIPTION
simdjson detects CPU capabilities at runtime and selects the appropriate optimized routines. So `-march=native` is not essential to getting good performance and I think it should be explicitly chosen by people who are sure they'll be running binaries on the same machines they're building.

This PR is motivated by a SIGILL I caught after building an application on a AVX-512 enabled Intel machine and running it on a slightly older AMD machine.