### PR TITLE
Allow newer dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,2 @@
 packages:
   ./hermes-json.cabal
-
--- Tests need some relaxed upper bounds for GHC 9.2.1
-allow-newer:
-    aeson:*
-  , hedgehog:*
-  , hsc2hs:*
-  , tasty-hedgehog:*
-  , terminal-size:*

--- a/hermes-json.cabal
+++ b/hermes-json.cabal
@@ -67,7 +67,7 @@ library
     scientific         >= 0.3.6 && < 0.4,
     text               >= 1.2.3.0 && < 1.3 || >= 2.0 && < 2.1,
     transformers       >= 0.5.6 && < 0.6,
-    time               >= 1.9.3 && < 1.10,
+    time               >= 1.9.3 && < 1.13,
     time-compat        >= 1.9.5 && < 1.10,
     unliftio           >= 0.2.14 && < 0.3,
     unliftio-core      >= 0.2.0 && < 0.3
@@ -120,15 +120,15 @@ test-suite hermes-test
   main-is:          test.hs
   ghc-options: -Wall 
   build-depends:    
-    aeson          >= 2.0.1 && < 2.1,
+    aeson          >= 2.0.1 && < 2.2,
     base,
     bytestring,
     containers     >= 0.6.2 && < 0.7,
     hermes-json,
     scientific,
     text,
-    hedgehog       >= 1.0.5 && < 1.1,
+    hedgehog       >= 1.0.5 && < 1.2,
     tasty          >= 1.4.2 && < 1.5,
-    tasty-hedgehog >= 1.1.0 && < 1.2,
+    tasty-hedgehog >= 1.1.0 && < 1.3,
     time
 


### PR DESCRIPTION
Tested using

    cabal test -w ghc-9.2.4 --enable-tests --constraint='aeson>=2.1' --constraint='hedgehog>=1.1' --constraint='tasty-hedgehog>=1.2' --constraint='time>=1.12'

This should make hermes-json work with Stackage nightly-2022-08-17 [which has time-1.11](https://www.stackage.org/nightly-2022-08-17/package/time-1.11.1.1).
