### PR TITLE
Internalize IO

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,41 +11,29 @@ on:
       - created
 jobs:
   ci:
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     strategy:
       matrix:
-        include:
-          - { os: ubuntu-20.04, ghc: 9.4.1 }
-          - { os: ubuntu-20.04, ghc: 9.2.1 }
-          - { os: ubuntu-20.04, ghc: 9.0.1 }
-          - { os: ubuntu-20.04, ghc: 8.10.7 }
-          - { os: macos-11, ghc: 9.4.1 }
-          - { os: macos-11, ghc: 9.2.1 }
-          - { os: macos-11, ghc: 9.0.1 }
-          - { os: windows-2019, ghc: 9.0.1 }
-    runs-on: ${{ matrix.os }}
+        ghc: ['9.4', '9.2', '8.10']
+        cabal: ['latest']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
       - run: mkdir artifact
-
       - run: mkdir artifact/${{ matrix.os }}
 
       - id: setup-haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: 3.8.1.0
-
+          cabal-version: ${{ matrix.cabal }}
       - run: cabal configure --enable-tests --flags strict --jobs
-
       - run: cabal freeze
-
       - run: cat cabal.project.freeze
-
       - run: cp cabal.project.freeze artifact/${{ matrix.os }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
           key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
@@ -53,7 +41,7 @@ jobs:
 
       - run: cabal build
 
-      - run: cabal test --test-show-details direct
+      - run: cabal test --enable-tests --test-show-details=direct
 
       - run: cabal check
 
@@ -67,11 +55,10 @@ jobs:
   release:
     needs: ci
     if: github.event_name == 'release'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: hermes-json-${{ github.sha }}
@@ -83,7 +70,7 @@ jobs:
         with:
           asset_content_type: application/gzip
           asset_name: hermes-json-${{ github.event.release.tag_name }}.tar.gz
-          asset_path: artifact/ubuntu-20.04/hermes-json-${{ github.event.release.tag_name }}.tar.gz
+          asset_path: artifact/ubuntu-latest/hermes-json-${{ github.event.release.tag_name }}.tar.gz
           upload_url: ${{ github.event.release.upload_url }}
 
       - run: cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' artifact/ubuntu-20.04/hermes-json-${{ github.event.release.tag_name }}.tar.gz

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library exposes functions that can be used to write decoders for JSON docum
 
 > You are working with stable JSON APIs which have a consistent layout and JSON dialect.
 
-With this in mind, `Data.Hermes` parsers can potentially decode Haskell types faster than traditional `Data.Aeson.FromJSON` instances, especially in cases where you only need to decode a subset of the document. This is because `Data.Aeson.FromJSON` converts the entire document into a `Data.Aeson.Value`, which means memory usage increases linearly with the input size. The `simdjson::ondemand` API does not have this constraint because it iterates over the JSON string in memory without constructing an intermediate tree. This means decoders are truly lazy and you only pay for what you use.
+With this in mind, `Data.Hermes` parsers can decode Haskell types faster than traditional `Data.Aeson.FromJSON` instances, especially in cases where you only need to decode a subset of the document. This is because `Data.Aeson.FromJSON` converts the entire document into a `Data.Aeson.Value`, which means memory usage increases linearly with the input size. The `simdjson::ondemand` API does not have this constraint because it iterates over the JSON string in memory without constructing an intermediate tree. This means decoders are truly lazy and you only pay for what you use.
 
 ## Usage
 
@@ -127,7 +127,6 @@ We benchmark the following operations using both `hermes-json` and `aeson` stric
 * Decode to `Text` instead of `String` wherever possible!
 * Decode to `Int` or `Double` instead of `Scientific` if you can.
 * Decode your object fields in order. Out of order field lookups will slightly degrade performance. If encoding with `aeson`, you can leverage `toEncoding` to enforce ordering.
-* You can improve performance by holding onto your own `HermesEnv`. `decodeEither` creates and destroys the simdjson instances every time it runs, which adds a performance penalty. Beware, do _not_ share a `HermesEnv` across multiple threads.
 
 ## Limitations
 

--- a/hermes-json.cabal
+++ b/hermes-json.cabal
@@ -51,12 +51,13 @@ library
     Data.Hermes.Decoder
     Data.Hermes.Decoder.Path
     Data.Hermes.Decoder.Time
-    Data.Hermes.Decoder.Types
     Data.Hermes.Decoder.Value
     Data.Hermes.SIMDJSON
     Data.Hermes.SIMDJSON.Bindings
     Data.Hermes.SIMDJSON.Types
     Data.Hermes.SIMDJSON.Wrapper
+  other-modules:
+    Data.Hermes.Decoder.Internal
   build-depends:
     attoparsec         >= 0.13.1 && < 0.15,
     attoparsec-iso8601 >= 1.0.2.0 && < 1.0.3.0,
@@ -69,9 +70,7 @@ library
     text               >= 1.2.3.0 && < 1.3 || >= 2.0 && < 2.1,
     transformers       >= 0.5.6 && < 0.6,
     time               >= 1.9.3 && < 1.13,
-    time-compat        >= 1.9.5 && < 1.10,
-    unliftio           >= 0.2.14 && < 0.3,
-    unliftio-core      >= 0.2.0 && < 0.3
+    time-compat        >= 1.9.5 && < 1.10
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -91,7 +90,6 @@ library
       -Wredundant-constraints
       -Wpartial-fields
       -Wmissed-specialisations
-      -Wunused-packages
   else
     ghc-options: -Wall
   cxx-sources:
@@ -111,8 +109,13 @@ library
     cbits
   install-includes:
     cbits/simdjson/simdjson.h
-  extra-libraries:
-    stdc++
+  if impl(ghc >= 9.4)
+    build-depends: system-cxx-std-lib == 1.0
+  elif os(darwin) || os(freebsd)
+    extra-libraries: c++
+  else
+    extra-libraries:
+      stdc++
 
 test-suite hermes-test
   default-language: Haskell2010

--- a/src/Data/Hermes/Decoder.hs
+++ b/src/Data/Hermes/Decoder.hs
@@ -4,5 +4,4 @@ module Data.Hermes.Decoder
 
 import           Data.Hermes.Decoder.Path as Export
 import           Data.Hermes.Decoder.Time as Export
-import           Data.Hermes.Decoder.Types as Export
 import           Data.Hermes.Decoder.Value as Export

--- a/src/Data/Hermes/Decoder/Path.hs
+++ b/src/Data/Hermes/Decoder/Path.hs
@@ -10,7 +10,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as T
 
-import           Data.Hermes.Decoder.Types (Decoder, HermesEnv(hPath))
+import           Data.Hermes.Decoder.Internal (Decoder, HermesEnv(hPath))
 
 withPath :: Text -> Decoder a -> Decoder a
 withPath key =

--- a/src/Data/Hermes/Decoder/Time.hs
+++ b/src/Data/Hermes/Decoder/Time.hs
@@ -19,7 +19,7 @@ import qualified Data.Time.Calendar.Month.Compat as Time
 import qualified Data.Time.Calendar.Quarter.Compat as Time
 import qualified Data.Time.LocalTime as Local
 
-import           Data.Hermes.Decoder.Types (Decoder)
+import           Data.Hermes.Decoder.Internal (Decoder)
 import           Data.Hermes.Decoder.Value (withText)
 import           Data.Hermes.SIMDJSON
 

--- a/src/Data/Hermes/SIMDJSON/Bindings.hs
+++ b/src/Data/Hermes/SIMDJSON/Bindings.hs
@@ -35,7 +35,8 @@ module Data.Hermes.SIMDJSON.Bindings
   , toDebugStringImpl
   ) where
 
-import           UnliftIO.Foreign (CBool(..), CInt(..), CSize(..), CString, FunPtr, Ptr)
+import           Foreign.C (CBool(..), CInt(..), CSize(..), CString)
+import           Foreign.Ptr (FunPtr, Ptr)
 
 import           Data.Hermes.SIMDJSON.Types
 
@@ -138,4 +139,3 @@ foreign import ccall unsafe "get_bool" getBoolImpl
 
 foreign import ccall unsafe "get_raw_json_token" getRawJSONTokenImpl
   :: Value -> Ptr CString -> Ptr CSize -> IO ()
-

--- a/src/Data/Hermes/SIMDJSON/Types.hs
+++ b/src/Data/Hermes/SIMDJSON/Types.hs
@@ -20,7 +20,7 @@ module Data.Hermes.SIMDJSON.Types
   )
   where
 
-import           UnliftIO.Foreign (Ptr)
+import           Foreign.Ptr (Ptr)
 
 -- | A reference to an opaque simdjson::ondemand::parser.
 newtype Parser = Parser (Ptr SIMDParser)
@@ -104,4 +104,3 @@ data SIMDErrorCode =
   | OUT_OF_BOUNDS
   | NUM_ERROR_CODES
   deriving (Eq, Show, Bounded, Enum)
-

--- a/src/Data/Hermes/SIMDJSON/Wrapper.hs
+++ b/src/Data/Hermes/SIMDJSON/Wrapper.hs
@@ -15,18 +15,11 @@ import qualified Data.ByteString.Unsafe as Unsafe
 import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           UnliftIO.Exception (bracket, mask_)
-import           UnliftIO.Foreign
-  ( ForeignPtr
-  , alloca
-  , allocaBytes
-  , finalizeForeignPtr
-  , newForeignPtr
-  , peek
-  , peekCString
-  , peekCStringLen
-  , withForeignPtr
-  )
+import           Control.Exception (bracket, mask_)
+import qualified Foreign.C as F
+import qualified Foreign.ForeignPtr as F
+import qualified Foreign.Marshal.Alloc as F
+import qualified Foreign.Storable as F
 
 import           Data.Hermes.SIMDJSON.Bindings
   ( currentLocationImpl
@@ -47,43 +40,43 @@ import           Data.Hermes.SIMDJSON.Types
   , SIMDParser
   )
 
-mkSIMDParser :: Maybe Int -> IO (ForeignPtr SIMDParser)
+mkSIMDParser :: Maybe Int -> IO (F.ForeignPtr SIMDParser)
 mkSIMDParser mCap = mask_ $ do
   let maxCap = 4000000000; -- 4GB
   ptr <- parserInit . toEnum $ fromMaybe maxCap mCap
-  newForeignPtr parserDestroy ptr
+  F.newForeignPtr parserDestroy ptr
 
-mkSIMDDocument :: IO (ForeignPtr SIMDDocument)
+mkSIMDDocument :: IO (F.ForeignPtr SIMDDocument)
 mkSIMDDocument = mask_ $ do
   ptr <- makeDocumentImpl
-  newForeignPtr deleteDocumentImpl ptr
+  F.newForeignPtr deleteDocumentImpl ptr
 
-mkSIMDPaddedStr :: ByteString -> IO (ForeignPtr PaddedString)
+mkSIMDPaddedStr :: ByteString -> IO (F.ForeignPtr PaddedString)
 mkSIMDPaddedStr input = mask_ $
   Unsafe.unsafeUseAsCStringLen input $ \(cstr, len) -> do
     ptr <- makeInputImpl cstr (fromIntegral len)
-    newForeignPtr deleteInputImpl ptr
+    F.newForeignPtr deleteInputImpl ptr
 
 -- | Construct a simdjson:padded_string from a Haskell `ByteString`, and pass
--- it to a monadic action. The instance lifetime is managed by the `bracket` function.
+-- it to an IO action. The instance lifetime is managed by the `bracket` function.
 withInputBuffer :: ByteString -> (InputBuffer -> IO a) -> IO a
 withInputBuffer bs f =
-  bracket acquire release $ \fPtr -> withForeignPtr fPtr $ f . InputBuffer
+  bracket acquire release $ \fPtr -> F.withForeignPtr fPtr $ f . InputBuffer
   where
-    acquire = liftIO $ mkSIMDPaddedStr bs
-    release = liftIO . finalizeForeignPtr
+    acquire = mkSIMDPaddedStr bs
+    release = F.finalizeForeignPtr
 
 -- | Read the document location and debug string. If the iterator is out of bounds
 -- then we abort reading from the iterator buffers to prevent reading garbage.
 getDocumentInfo :: Document -> IO (Text, Text)
-getDocumentInfo docPtr = alloca $ \locStrPtr -> alloca $ \lenPtr -> do
+getDocumentInfo docPtr = F.alloca $ \locStrPtr -> F.alloca $ \lenPtr -> do
   err <- liftIO $ currentLocationImpl docPtr locStrPtr
   let errCode = toEnum $ fromIntegral err
   if errCode == OUT_OF_BOUNDS
     then pure ("out of bounds", "")
-    else allocaBytes 128 $ \dbStrPtr -> do
-      locStr <- fmap T.pack $ peekCString =<< peek locStrPtr
+    else F.allocaBytes 128 $ \dbStrPtr -> do
+      locStr <- fmap T.pack $ F.peekCString =<< F.peek locStrPtr
       toDebugStringImpl docPtr dbStrPtr lenPtr
-      len <- fmap fromIntegral $ peek lenPtr
-      debugStr <- fmap T.pack $ peekCStringLen (dbStrPtr, len)
+      len <- fmap fromIntegral $ F.peek lenPtr
+      debugStr <- fmap T.pack $ F.peekCStringLen (dbStrPtr, len)
       pure (locStr, debugStr)


### PR DESCRIPTION
* Internalizes IO functions used for FFI (via Internal module)
* Removes MonadIO and MonadUnliftIO instances for Decoder
* Clean up some docs and code
* Update C++ library linking in cabal file

Resolves #17 and #13