### PR TITLE
Bump versions in hermes-json.cabal

### DIFF
--- a/hermes-json.cabal
+++ b/hermes-json.cabal
@@ -60,7 +60,7 @@ library
     Data.Hermes.Decoder.Internal
   build-depends:
     attoparsec         >= 0.13.1 && < 0.15,
-    attoparsec-iso8601 >= 1.0.2.0 && < 1.0.3.0,
+    attoparsec-iso8601 >= 1.0.2.0 && < 1.2,
     base               >= 4.13 && < 4.18,
     bytestring         >= 0.10.12 && < 0.12,
     containers         >= 0.6.5 && < 0.7,
@@ -133,8 +133,8 @@ test-suite hermes-test
     hermes-json,
     scientific,
     text,
-    hedgehog       >= 1.0.5 && < 1.2,
+    hedgehog       >= 1.0.5 && < 1.3,
     tasty          >= 1.4.2 && < 1.6,
-    tasty-hedgehog >= 1.1.0 && < 1.4,
+    tasty-hedgehog >= 1.1.0 && < 1.5,
     time,
     vector


### PR DESCRIPTION
This PR just bumps some of the upper bounds on dependencies in `hermes-json.cabal`.

I ran into this when trying to get `hermes-json` building in Nixpkgs (which is currently based on LTS-21).  Related to https://github.com/NixOS/nixpkgs/pull/240387/commits/c5bb5c1e54232fa37024d5186c5ba6e4b83db0de, which is included in https://github.com/NixOS/nixpkgs/pull/240387.